### PR TITLE
Updating mbed-os to mbed-os-5.13.3

### DIFF
--- a/NFC_EEPROM/mbed-os.lib
+++ b/NFC_EEPROM/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#7482462434d5cf718177653ef797547a976a7c5e
+https://github.com/ARMmbed/mbed-os/#808c45062f940790e1287bd6b8420290c062775c

--- a/NFC_SmartPoster/mbed-os.lib
+++ b/NFC_SmartPoster/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#7482462434d5cf718177653ef797547a976a7c5e
+https://github.com/ARMmbed/mbed-os/#808c45062f940790e1287bd6b8420290c062775c


### PR DESCRIPTION
Please test this PR

If successful then merge, otherwise provide a known issue.
Once you get notification of the release being made public then tag Master with mbed-os-5.13.3 . 