### PR TITLE
main: fix printf  include

### DIFF
--- a/NFC_EEPROM/source/main.cpp
+++ b/NFC_EEPROM/source/main.cpp
@@ -23,6 +23,7 @@
 #include "NFCEEPROM.h"
 
 #include "EEPROMDriver.h"
+#include <cstdio>
 
 using events::EventQueue;
 


### PR DESCRIPTION
This PR https://github.com/ARMmbed/mbed-os/pull/12581 failed due to removing some header files that could affect this.

Failures are
```
Compile [ 99.1%]: main.cpp
[Error] main.cpp@52,13: use of undeclared identifier 'printf'
[Error] main.cpp@64,13: use of undeclared identifier 'printf'
[Error] main.cpp@66,13: use of undeclared identifier 'printf'
[Error] main.cpp@74,13: use of undeclared identifier 'printf'
[Error] main.cpp@76,13: use of undeclared identifier 'printf'
[Error] main.cpp@81,9: use of undeclared identifier 'printf'
[Error] main.cpp@85,9: use of undeclared identifier 'printf'
```