### PR TITLE
CMake: Fix missing configuration module

### DIFF
--- a/NFC_EEPROM/CMakeLists.txt
+++ b/NFC_EEPROM/CMakeLists.txt
@@ -18,6 +18,8 @@ mbed_set_mbed_target_linker_script(${APP_TARGET})
 
 project(${APP_TARGET})
 
+include(${MBED_CONFIG_PATH}/mbed_config.cmake)
+
 add_subdirectory(source/target)
 
 target_include_directories(${APP_TARGET}


### PR DESCRIPTION
This was missing from the previous commit.
The application needs to be aware of the configuration module in order to use the target labels to add subdirectory to build EEPROM drivers.

Reviewers
@0xc0170 