### PR TITLE
CMake: replace usage of the mbed_add_cmake_directory_if_labels() func

### DIFF
--- a/NFC_EEPROM/source/target/CMakeLists.txt
+++ b/NFC_EEPROM/source/target/CMakeLists.txt
@@ -1,7 +1,11 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-mbed_add_cmake_directory_if_labels("TARGET")
+if("M24SR" IN_LIST MBED_TARGET_LABELS)
+    add_subdirectory(TARGET_M24SR)
+elseif("PN512" IN_LIST MBED_TARGET_LABELS)
+    add_subdirectory(TARGET_PN512)
+endif()
 
 target_include_directories(${APP_TARGET}
     PUBLIC


### PR DESCRIPTION
- The directory starts with special prefixes `TARGET_`  gets added into the build based on target configuration instead of calling utility function mbed_add_cmake_directory_if_labels().

### Reviewers <!-- Optional -->
@hugueskamba 