### PR TITLE
Add PN512 into target config

### DIFF
--- a/NFC_SmartPoster/mbed_app.json
+++ b/NFC_SmartPoster/mbed_app.json
@@ -1,5 +1,8 @@
 {
     "target_overrides": {
+        "DISCO_L475VG_IOT01A": {
+            "target.extra_labels_add": ["PN512"]
+        },
         "NUCLEO_F401RE": {
             "target.extra_labels_add": ["PN512"]
         }


### PR DESCRIPTION
- Add the PN512 NFC driver config in mbed_app.json to include PN512 driver source

_Note:_ 
@jamesbeyond manually tested this example in DISCO_L475VG target with PN512 NFC controller shield.

### Reviewers <!-- Optional -->
@0xc0170 @pan- @hugueskamba 