### PR TITLE
Unify example

### DIFF
--- a/NFC_EEPROM/README.md
+++ b/NFC_EEPROM/README.md
@@ -1,52 +1,28 @@
 # NFC EEPROM usage example
 
-Demonstration of possible usage of the NFC EEPROM class. 
+Demonstration of possible usage of the `NFCEEPROM` class. 
 
-The application will write an URL to the EEPROM of the NFC tag on your board. This will be able to be read by any NFC device capable of reading NFC tags.
+The application will write an URL to the EEPROM of the NFC tag on your board.
+This will be able to be read by any NFC device capable of reading NFC tags.
 
-The example needs to supply a driver for the EEPROM. The `M24SR` and `ST25DV` EEPROM drivers are provided for the `DISCO_L475VG_IOT01A` and `NUCLEO_F401RE` targets respectively. The `PN512` EEPROM driver is also provided for the `NUCLEO_F401RE` target. You may wish to add your own driver or update the configuration if you're using a different target.
+The example needs to supply a driver for the EEPROM. The `M24SR` and `ST25DV` EEPROM drivers are provided for the
+`DISCO_L475VG_IOT01A` and `NUCLEO_F401RE` targets respectively. The `PN512` EEPROM driver is also provided for the
+`NUCLEO_F401RE` target. You may wish to add your own driver or update the configuration if you're using a different target.
 
 # Running the application
 
 ## Requirements
 
-Verification of the sample application can be seen on any smartphone with a NFC reader. After running you will be able to read the tag with a NFC tag reader application running on the smartphone.
+This example is known to work on the `DISCO_L475VG_IOT01A` target which uses the [`M24SR`](./source/target/TARGET_M24SR)
+driver. It also works on the `NUCLEO_F401RE` target which uses the [`ST25DV`](./source/target/TARGET_ST25DV) driver.
+Alternatively, the `NUCLEO_F401RE` target can use the[`PN512`](./source/target/TARGET_PN512) driver. The three drivers
+are downloaded during deployment with `mbed deploy`.
 
-Information about activity is also printed on the serial interface. See the [official documentation website](https://os.mbed.com/docs/mbed-os/v5.15/tutorials/serial-comm.html#using-terminal-applications) for more informartion about using serial terminals.
+If you want to use a different driver, create a new directory similar to the ones found in the
+[./source/target/](./source/target/) and update the content of the library file (`eeprom_driver.lib`) found in it to
+point to the Git repository containing the driver.
 
-As mentioned above, you will also need to supply the driver for the EEPROM. This example is known to work on the `DISCO_L475VG_IOT01A` target which uses the [`M24SR`](./source/target/TARGET_M24SR) driver. It also works on the `NUCLEO_F401RE` target which uses the [`ST25DV`](./source/target/TARGET_ST25DV) driver. Alternatively, the `NUCLEO_F401RE` target can use the[`PN512`](./source/target/TARGET_PN512) driver. The three drivers are downloaded during deployment with `mbed deploy`. If you want to use a different driver, create a new directory similar to the ones found in the [./source/target/](./source/target/) and update the content of the library file (`eeprom_driver.lib`) found in it to point to the Git repository containing the driver.
+### Building and running
 
-## Building instructions
-
-Clone this repository:
-
-```
-git clone https://github.com/ARMmbed/mbed-os-example-nfc.git
-```
-
-Navigate to the example:
-
-```
-cd mbed-os-example-nfc/NFC_EEPROM
-```
-
-Update the source tree:
-
-```
-mbed deploy
-```
-
-If your are not using a `DISCO_L475VG_IOT01A` or a `NUCLEO_F401RE` you should indicate in the application configuration file ([`mbed_app.json`](./mbed_app.json)) which driver should be selected by the build system as follows:
-
-```json
-    "<TARGET_NAME>": {
-        "target.extra_labels_add": ["<DRIVER_NAME>"]
-    }
-```
-
-
-Build the application:
-
-```
-mbed compile -t <TOOLCHAIN> -m <TARGET>
-```
+Building and further running instructions for all samples are in the
+[main readme](https://github.com/ARMmbed/mbed-os-example-nfc/blob/master/README.md).

--- a/NFC_EEPROM/mbed_app.json
+++ b/NFC_EEPROM/mbed_app.json
@@ -1,5 +1,8 @@
 {
     "target_overrides": {
+        "*": {
+            "platform.stdio-baud-rate": 115200
+        },
         "DISCO_L475VG_IOT01A": {
             "target.extra_labels_add": ["M24SR"]
         },

--- a/NFC_SmartPoster/README.md
+++ b/NFC_SmartPoster/README.md
@@ -10,17 +10,16 @@ The smart poster record generated contains:
 - A title: "mbed website"
 - An action: `EXECUTE` which asks the peer to open the URI.
 
-# Running the application
+## Running the application
 
-## Requirements
-
-Verification of the sample application can be seen on any a smartphone with an NFC reader. After running you will be able to read the tag with an NFC tag reader application.
+### Requirements
 
 This example is known to work on boards connected to a PN512 shield.
 
 **Wiring diagram for NFC Explorer with PN512**
 
-If using the Raspbery Pi explorer (PN512) board, use this pinout mapping diagram to connect the shield to the reference target. In this case a ST NucleoF401RE pinout is shown.
+If using the Raspbery Pi explorer (PN512) board, use this pinout mapping diagram to connect the shield to the reference
+target. In this case a ST NucleoF401RE pinout is shown.
 
               Nucleo F401RE                Explore NFC                 
              (Arduino header)        (pin1 on shield shown with a <|)
@@ -46,34 +45,9 @@ If using the Raspbery Pi explorer (PN512) board, use this pinout mapping diagram
     Patch using jumper wires to the             
     indicated pins on the Shield.            
 
-
 Schematic (https://www.element14.com/community/docs/DOC-76384/l/explore-nfc-board-schematic)
 
+### Building and running
 
-## Building instructions
-
-Clone the repository containing the collection of examples:
-
-```
-git clone https://github.com/ARMmbed/mbed-os-example-nfc.git
-```
-
-Using a command-line tool, navigate to the exmaple:
-
-```
-cd mbed-os-example-nfc
-cd NFC_SmartPoster
-```
-
-Update the source tree:
-
-```
-mbed deploy
-```
-
-Run the build:
-
-```
-mbed compile -t <ARM | GCC_ARM> -m <YOUR_TARGET>
-```
-
+Building and further running instructions for all samples are in the
+[main readme](https://github.com/ARMmbed/mbed-os-example-nfc/blob/master/README.md).

--- a/NFC_SmartPoster/main.cpp
+++ b/NFC_SmartPoster/main.cpp
@@ -61,7 +61,8 @@ public:
      * @param queue The event queue that will be used by the NFCController.
      */
     NFCProcess(events::EventQueue &queue) :
-        _pn512_transport(D11, D12, D13, D10, A1, A0),
+        /*(PinName mosi, PinName miso, PinName sclk, PinName ssel, PinName irq, PinName rst);*/
+        _pn512_transport(PA_12, PA_11, PA_1, PA_15, A1, A0),
         _pn512_driver(&_pn512_transport),
         _queue(queue),
         _ndef_buffer(),

--- a/NFC_SmartPoster/mbed_app.json
+++ b/NFC_SmartPoster/mbed_app.json
@@ -1,5 +1,8 @@
 {
     "target_overrides": {
+        "*": {
+            "platform.stdio-baud-rate": 115200
+        },
         "NUCLEO_F401RE": {
             "target.extra_labels_add": ["PN512"]
         }

--- a/README.md
+++ b/README.md
@@ -1,14 +1,87 @@
 ![](./resources/official_armmbed_example_badge.png)
 # Mbed OS NFC examples 
 
-This repository contains all Mbed OS NFC examples actively developped and maintained by the Mbed OS team. 
+This repo contains NFC example applications based on mbed OS and built with [mbed-cli](https://github.com/ARMmbed/mbed-cli).
 
+Each example directory prefixed with `NFC_` contains an Mbed os project.
 
-# Known issues 
+The [NFC documentation](https://os.mbed.com/docs/latest/apis/nfc-technology.html) describes the NFC APIs on mbed OS.
+
+## Using the examples
+
+### Targets for NFC
+
+To build these examples, you need to have a computer with software installed as described [here](https://os.mbed.com/docs/latest/tools/index.html).
+
+In order to use NFC in mbed OS you will need a baord with an NFC controller or a shield. These examples have been
+tested on:
+- `DISCO_L475VG_IOT01A` with its built in `M24SR`
+- `NUCLEO_F401RE` board with a `NXP PN512` shield
+
+But any board with a NFC shield should work. See documentation for the driver for your shield/board for details.
+
+### Building and flashing examples
+
+__To build an example:__
+
+* Clone the repository containing the collection of examples:
+
+	```
+	$ git clone https://github.com/ARMmbed/mbed-os-example-nfc.git
+	```
+
+	**Tip:** If you don't have git installed, you can [download a zip file](https://github.com/ARMmbed/mbed-os-example-nfc/archive/master.zip) of the repository.
+
+* Using a command-line tool, navigate to any of the example directories, like NFC EEPROM:
+
+	```
+	$ cd mbed-os-example-nfc
+	$ cd NFC_EEPROM
+	```
+
+* Update the source tree:
+
+	```
+	mbed deploy
+	```
+
+* Run the build:
+
+	```
+	mbed compile -t <ARM | GCC_ARM> -m <YOUR_TARGET>
+    ```
+
+__To run the application on your board:__
+
+* Connect your mbed board to your computer over USB. It appears as removable storage.
+
+* When you run the `mbed compile` command above, mbed cli creates a .bin or a .hex file (depending on your target) in
+```BUILD/<target-name>/<toolchain>``` under the example's directory. Drag and drop the file to the removable storage.
+
+Alternatively you may launch compilation with `-f` flag to have mbed tools attempt to flash your board.
+The tools will flash the binary to all targets that match the board specified by '-m' parameter. 
+
+### Running the examples
+
+When example application is running information about activity is printed over the serial connection.
+The default serial baudrate has been set to 115200 for these examples.
+
+Please have a client open and connected to the board. You may use:
+
+- [Tera Term](https://ttssh2.osdn.jp/index.html.en) for windows
+
+- screen or minicom for Linux (example usage: `screen /dev/serial/<your board> 115200`)
+
+- mbed tools have terminal command `mbed term -b 115200`
+
+Verification of the sample application can be seen on any a smartphone with an NFC reader.
+After running you will be able to read the tag with an NFC tag reader application.
+
+#### Known issues 
 
 The repository is not meant to be imported directly inside the Mbed online compiler. To import one example inside the online compiler, go to https://os.mbed.com/teams/mbed-os-examples/ and import from here the NFC example of your choice.
 
-## License and contributions
+### License and contributions
 
 The software is provided under Apache-2.0 license. Contributions to this project are accepted under the same license. Please see [contributing.md](CONTRIBUTING.md) for more info.
 


### PR DESCRIPTION
Unify the readmes. Fix the baud rate of the example to be in line with all the others.

Added a comment to smart poster constructor to help wire the PN512.