### PR TITLE
M24SR: Use driver from Mbed OS repository

### DIFF
--- a/NFC_EEPROM/EEPROMDriver/target/TARGET_M24SR/CMakeLists.txt
+++ b/NFC_EEPROM/EEPROMDriver/target/TARGET_M24SR/CMakeLists.txt
@@ -1,14 +1,7 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-target_include_directories(${APP_TARGET}
-    PUBLIC
-        ${CMAKE_CURRENT_SOURCE_DIR}/eeprom_driver
-)
-
 target_sources(${APP_TARGET}
     PRIVATE
         EEPROMDriver.cpp
-
-        eeprom_driver/m24sr_driver.cpp
 )

--- a/NFC_EEPROM/EEPROMDriver/target/TARGET_M24SR/eeprom_driver.lib
+++ b/NFC_EEPROM/EEPROMDriver/target/TARGET_M24SR/eeprom_driver.lib
@@ -1,1 +1,0 @@
-https://github.com/ARMmbed/mbed-nfc-m24sr


### PR DESCRIPTION
Mbed OS now provides the driver thus remove lib file
to download it from another external repository.

Preceding PR: https://github.com/ARMmbed/mbed-os/pull/14092