### PR TITLE
Remove deprecated function from CMakeLists.txt

### DIFF
--- a/NFC_EEPROM/CMakeLists.txt
+++ b/NFC_EEPROM/CMakeLists.txt
@@ -15,8 +15,6 @@ add_executable(${APP_TARGET})
 
 mbed_configure_app_target(${APP_TARGET})
 
-mbed_set_mbed_target_linker_script(${APP_TARGET})
-
 project(${APP_TARGET})
 
 include(${MBED_CONFIG_PATH}/mbed_config.cmake)

--- a/NFC_SmartPoster/CMakeLists.txt
+++ b/NFC_SmartPoster/CMakeLists.txt
@@ -15,8 +15,6 @@ add_executable(${APP_TARGET})
 
 mbed_configure_app_target(${APP_TARGET})
 
-mbed_set_mbed_target_linker_script(${APP_TARGET})
-
 project(${APP_TARGET})
 
 include(${MBED_CONFIG_PATH}/mbed_config.cmake)


### PR DESCRIPTION
`mbed_set_mbed_target_linker_script` was removed from mbed-os.

This PR depends on ARMmbed/mbed-os#14199