### PR TITLE
Generic error message in SmartPoster_noShield.log

### DIFF
--- a/tests/SmartPoster_noShield.log
+++ b/tests/SmartPoster_noShield.log
@@ -1,1 +1,1 @@
-Initialize: ret = 16
+MbedOS Error Info


### PR DESCRIPTION
Current error message is no longer working. Updating to a generic error message.