### PR TITLE
CMake: Link with mbed-events as the application requires it

### DIFF
--- a/NFC_EEPROM/CMakeLists.txt
+++ b/NFC_EEPROM/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 ARM Limited. All rights reserved.
+# Copyright (c) 2020-2021 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
@@ -12,8 +12,6 @@ include(${MBED_PATH}/tools/cmake/app.cmake)
 add_subdirectory(${MBED_PATH})
 
 add_executable(${APP_TARGET})
-
-mbed_configure_app_target(${APP_TARGET})
 
 project(${APP_TARGET})
 
@@ -36,6 +34,7 @@ target_sources(${APP_TARGET}
 target_link_libraries(${APP_TARGET}
     PRIVATE
         mbed-os
+        mbed-events
         mbed-nfc
 )
 


### PR DESCRIPTION
As we are moving to CMake OBJECT libraries for optional
components, applications can no longer rely on them
to obtain other libraries they themselves need.

Also remove call to mbed_configure_app_target() as it is
no longer required.

Reviewers
@0xc0170 