### PR TITLE
Update Arduino pin names

### DIFF
--- a/NFC_EEPROM/EEPROMDriver/target/TARGET_PN512/EEPROMDriver.cpp
+++ b/NFC_EEPROM/EEPROMDriver/target/TARGET_PN512/EEPROMDriver.cpp
@@ -33,7 +33,7 @@ NFCEEPROMDriver& get_eeprom_driver(events::EventQueue& queue)
     static uint8_t ndef_controller_buffer[1024] = { 0 };
     static uint8_t eeprom_buffer[1024] = { 0 };
 
-    static PN512SPITransportDriver pn512_transport(D11, D12, D13, D10, A1, A0);
+    static PN512SPITransportDriver pn512_transport(ARDUINO_UNO_D11, ARDUINO_UNO_D12, ARDUINO_UNO_D13, ARDUINO_UNO_D10, ARDUINO_UNO_A1, ARDUINO_UNO_A0);
     static PN512Driver pn512_driver(&pn512_transport);
 
     static NFCController nfc_controller(

--- a/NFC_EEPROM/mbed_app.json
+++ b/NFC_EEPROM/mbed_app.json
@@ -17,9 +17,9 @@
         },
         "NRF52840_DK": {
             "target.extra_labels_add": ["NT3H2111"],
-            "MBED_NFC_NT3H2111.sda": "D14",
-            "MBED_NFC_NT3H2111.scl": "D15",
-            "MBED_NFC_NT3H2111.fd": "D5"
+            "MBED_NFC_NT3H2111.sda": "ARDUINO_UNO_D14",
+            "MBED_NFC_NT3H2111.scl": "ARDUINO_UNO_D15",
+            "MBED_NFC_NT3H2111.fd": "ARDUINO_UNO_D5"
         }
     }
 }

--- a/NFC_SmartPoster/mbed_app.json
+++ b/NFC_SmartPoster/mbed_app.json
@@ -17,8 +17,8 @@
             "pn512_miso": "PA_6",
             "pn512_sclk": "PA_5",
             "pn512_ssel": "PB_6",
-            "pn512_irq": "A1",
-            "pn512_reset": "A0"
+            "pn512_irq": "ARDUINO_UNO_A1",
+            "pn512_reset": "ARDUINO_UNO_A0"
         },
         "NUCLEO_L433RC_P": {
             "target.extra_labels_add": ["PN512"],
@@ -26,8 +26,8 @@
             "pn512_miso": "PA_11",
             "pn512_sclk": "PA_1",
             "pn512_ssel": "PA_15",
-            "pn512_irq": "A1",
-            "pn512_reset": "A0"
+            "pn512_irq": "ARDUINO_UNO_A1",
+            "pn512_reset": "ARDUINO_UNO_A0"
         }
     }
 }


### PR DESCRIPTION
This PR updates this example to use the new Arduino pin names (e.g. D0 -> ARDUINO_UNO_D0).