### PR TITLE
Update for mbed-os-6.12.0

### DIFF
--- a/NFC_EEPROM/mbed-os.lib
+++ b/NFC_EEPROM/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#14e5d307bb6cdccb554b591ab2602d8d47e0b2d0
+https://github.com/ARMmbed/mbed-os/#cecc47b4a53951527dd3f670465c8566396ad101

--- a/NFC_SmartPoster/mbed-os.lib
+++ b/NFC_SmartPoster/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#14e5d307bb6cdccb554b591ab2602d8d47e0b2d0
+https://github.com/ARMmbed/mbed-os/#cecc47b4a53951527dd3f670465c8566396ad101


### PR DESCRIPTION
This pull request updates the example to be compatible with the 
mbed-os-6.12.0 release of mbed-os. 