### PR TITLE
CMake: Make applications the top level CMake projects

### DIFF
--- a/NFC_EEPROM/CMakeLists.txt
+++ b/NFC_EEPROM/CMakeLists.txt
@@ -9,11 +9,11 @@ set(APP_TARGET NFC_EEPROM)
 
 include(${MBED_PATH}/tools/cmake/app.cmake)
 
+project(${APP_TARGET})
+
 add_subdirectory(${MBED_PATH})
 
 add_executable(${APP_TARGET})
-
-project(${APP_TARGET})
 
 include(${MBED_CONFIG_PATH}/mbed_config.cmake)
 

--- a/NFC_SmartPoster/CMakeLists.txt
+++ b/NFC_SmartPoster/CMakeLists.txt
@@ -9,11 +9,11 @@ set(APP_TARGET NFC_SmartPoster)
 
 include(${MBED_PATH}/tools/cmake/app.cmake)
 
+project(${APP_TARGET})
+
 add_subdirectory(${MBED_PATH})
 
 add_executable(${APP_TARGET})
-
-project(${APP_TARGET})
 
 include(${MBED_CONFIG_PATH}/mbed_config.cmake)
 


### PR DESCRIPTION
So CMake can work correctly we need to define our project before we add
dependencies, otherwise the project we depend on will be registered as
the current project.