### PR TITLE
Fix CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,12 +55,10 @@ jobs:
           cd mbed-os-example-nfc
           cd NFC_SmartPoster
           mbed-tools compile -t GCC_ARM -m NUCLEO_F401RE || exit 1
-          mbed-tools compile -t ARM -m NUCLEO_F401RE || exit 1
       - run: |
           cd mbed-os-example-nfc
           cd NFC_EEPROM
           mbed-tools compile -t GCC_ARM -m NUCLEO_F401RE || exit 1
-          mbed-tools compile -t ARM -m NUCLEO_F401RE || exit 1
 
   cmake_disco_l475vg:
     docker:
@@ -74,7 +72,6 @@ jobs:
           cd mbed-os-example-nfc
           cd NFC_EEPROM
           mbed-tools compile -t GCC_ARM -m DISCO_L475VG_IOT01A || exit 1
-          mbed-tools compile -t ARM -m DISCO_L475VG_IOT01A || exit 1
 
   cmake_k64f:
     docker:
@@ -88,7 +85,6 @@ jobs:
           cd mbed-os-example-nfc
           cd NFC_EEPROM
           mbed-tools compile -t GCC_ARM -m K64F || exit 1
-          mbed-tools compile -t ARM -m K64F || exit 1
 
 workflows:
   version: 2


### PR DESCRIPTION
mbed-os-env does not contain the ARM toolchain, yet we were trying to
build the examples using the ARM toolchain.